### PR TITLE
Checking if mobile type exists to avoid null pointer crash

### DIFF
--- a/src/main/java/com/mobeelizer/mobile/android/MobeelizerRealConnectionManager.java
+++ b/src/main/java/com/mobeelizer/mobile/android/MobeelizerRealConnectionManager.java
@@ -264,11 +264,17 @@ class MobeelizerRealConnectionManager implements MobeelizerConnectionManager {
     }
 
     private boolean isConnecting(final ConnectivityManager connectivityManager) {
+        if (connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE) == null) {
+			return connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI).isConnectedOrConnecting();
+		}
         return connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI).isConnectedOrConnecting()
                 || connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE).isConnectedOrConnecting();
     }
 
     private boolean isConnected(final ConnectivityManager connectivityManager) {
+		if (connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE) == null) {
+			return connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI).isConnected();
+		}
         return connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI).isConnected()
                 || connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_MOBILE).isConnected();
     }


### PR DESCRIPTION
Checking if there is a Mobile radio hardware, else on wifi only android devices, this produces a null pointer error. Please merge and add this logic wherever applicable.
